### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -562,7 +562,7 @@ Raw commands
 
       **Syntax:** *gamerule <rule> [value]*
 
-      A complete list of game rules are available at https://minecraft.fandom.com/wiki/Game_rule#List_of_game_rules.
+      A complete list of game rules are available at https://minecraft.wiki/w/Game_rule#List_of_game_rules.
 
       :param str rule: ``rule``
       :param value: ``value``

--- a/pymcfunc_old/rawcommands.py
+++ b/pymcfunc_old/rawcommands.py
@@ -101,7 +101,7 @@ class UniversalRawCommands:
 
     def gamerule(self, rule: str, value: Union[bool, int]=None):
         """**Syntax:** *gamerule <rule> [value]*\n
-        A complete list of game rules are available at https://minecraft.fandom.com/wiki/Game_rule#List_of_game_rules\n
+        A complete list of game rules are available at https://minecraft.wiki/w/Game_rule#List_of_game_rules\n
         More info: https://pymcfunc.rtfd.io/en/latest/reference.html#pymcfunc.UniversalRawCommands.gamerule"""
         BEDROCK = {
             bool: ['commandBlocksEnabled', 'commandBlockOutput', 'doDaylightCycle', 'doEntityDrops', 'doFireTick', 'doInsomnia',


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki